### PR TITLE
Add ARC compatibility to substrate.h

### DIFF
--- a/include/substrate.h
+++ b/include/substrate.h
@@ -164,7 +164,11 @@ static inline void MSHookMessage(Class _class, SEL sel, Type_ *imp, Type_ **resu
 template <typename Type_>
 static inline Type_ &MSHookIvar(id self, const char *name) {
     Ivar ivar(class_getInstanceVariable(object_getClass(self), name));
-    void *pointer(ivar == NULL ? NULL : reinterpret_cast<char *>(self) + ivar_getOffset(ivar));
+    #if __has_feature(objc_arc)
+        void *pointer(ivar == NULL ? NULL : reinterpret_cast<char *>((__bridge void *)self) + ivar_getOffset(ivar));
+    #else
+        void *pointer(ivar == NULL ? NULL : reinterpret_cast<char *>(self) + ivar_getOffset(ivar));
+    #endif
     return *reinterpret_cast<Type_ *>(pointer);
 }
 


### PR DESCRIPTION
Fixes `substrate.h` when using ARC.
