### PR TITLE
Signing with entitlements.xml

### DIFF
--- a/bin/iosod
+++ b/bin/iosod
@@ -526,7 +526,7 @@ function signCode() # args: executableToSign, identityToSignWith
 		if [[ -n "$entitlements" ]]; then
 			echo "Signing with entitlements..."
 			cmdArg+=("--entitlements" "$entitlements")
-		else
+		fi
 	fi
 
 	echo -n "Signing $executableToSign with `basename \"$cmdBin\"`... "


### PR DESCRIPTION
Is it possible to make an executable get signed with entitlements, like this file:

```
<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
<plist version="1.0">
<dict>
            <key>com.apple.springboard.debugapplications</key>
            <true/>
            <key>proc_info-allow</key>
            <true/>
            <key>get-task-allow</key>
            <true/>
            <key>run-unsigned-code</key>
            <true/>
            <key>task_for_pid-allow</key>
            <true/>
</dict>
</plist>
```

You normally do this with either of these:

```
ldid -Sentitlements.xml <executable>
codesign -f -s <identity> --entitlements entitlements.xml <executable>
```
