### PR TITLE
Show logos errors (again)

### DIFF
--- a/bin/iosod
+++ b/bin/iosod
@@ -1529,9 +1529,9 @@ function xcodeBuildPhase_Logos() # no args
 			logosErr=$?
 		
 		if [[ $logosErr != 0 ]]; then
-			echo "Failed Logos Processor"
-			echo "Logos Processor outputted:"
-			echo "$logosStdErr"
+			echo "Failed Logos Processor" >&2
+			echo "Logos Processor outputted:" >&2
+			echo "$logosStdErr" >&2
 			exit $logosErr
 		fi
 		


### PR DESCRIPTION
You seem to have already implemented this, however it doesn't work as you will always call `panic` before printing the error.
