### PR TITLE
Add private include & template directories to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,7 @@
 .DocumentRevisions-V100
 .Spotlight-V100
 .vol
-Icon
+Icon
+frameworks
+include/SpringBoard
+templates


### PR DESCRIPTION
By adding the `frameworks`, `include/SpringBoard`, and `templates` directories to the gitignore file, we can use `/opt/iOSOpenDev` as a git working copy and directly commit changes made to the live environment.

(Any permissions issues when trying to access the directory without running as root should be easily resolvable by running `sudo chown -R $USER /opt/iOSOpenDev`, of course.)